### PR TITLE
Add reload based on arbitrary command output. 

### DIFF
--- a/captain
+++ b/captain
@@ -235,7 +235,7 @@ manual() {
     fi && mkfifo "$process"
     for file in $treasure/*; do
         name=$(basename $file)
-        if [[ "$(eval "echo \${${name}_reload"})" -eq "-1" ]]; then
+        if [[ ! -z $(tr -d [:digit:]. <<< $(eval "echo \${${name}_reload"})) ]]; then
             if [[ $(eval "echo \${${name}_manual}") = true ]]; then
                 while read -r output; do
                     manual "$name" "$file"
@@ -243,7 +243,7 @@ manual() {
                         "${name}@" \
                         "${content}" \
                         $'\n' > "$process" &
-                done < <($(eval "echo \${${name}_reloadcommand"})) &
+                done < <($(eval "echo \${${name}_reload"})) &
             else
                  while read -r output; do
                     printf "%s" \
@@ -257,7 +257,7 @@ manual() {
                         "$(eval "echo \${area[${name}_s]"})" \
                         "%{-o}%{-uU-}" \
                         $'\n' > "$process" &
-                done < <($(eval "echo \${${name}_reloadcommand"})) &
+                done < <($(eval "echo \${${name}_reload"})) &
             fi
         else
             if [[ $(eval "echo \${${name}_manual}") = true ]]; then
@@ -304,7 +304,7 @@ If you're still confused, remember that the wiki exists: https://github.com/muse
 ===== ===== ===== ===== ===== ====="
 
 # Start captain.
-cat "$process"| format | lemonbar \
+cat "$process" | format | lemonbar \
     $(echo "-o $bar_offset") \
     $(printf " -f %s" "${bar_fonts[@]}") \
     $(echo "-${bar_dock//[^b]/}") \

--- a/captain
+++ b/captain
@@ -235,30 +235,56 @@ manual() {
     fi && mkfifo "$process"
     for file in $treasure/*; do
         name=$(basename $file)
-        if [[ $(eval "echo \${${name}_manual}") = true ]]; then
-            while :; do
-                manual "$name" "$file"
-                printf "%s" \
-                    "${name}@" \
-                    "${content}" \
-                    $'\n'
-                sleep $(eval "echo \${${name}_reload"})
-            done > "$process" &
+        if [[ "$(eval "echo \${${name}_reload"})" -eq "-1" ]]; then
+            if [[ $(eval "echo \${${name}_manual}") = true ]]; then
+                while read -r output; do
+                    manual "$name" "$file"
+                    printf "%s" \
+                        "${name}@" \
+                        "${content}" \
+                        $'\n' > "$process" &
+                done < $(eval "echo \${${name}_reloadcommand"})
+            else
+                 while read -r output; do
+                    printf "%s" \
+                        "${name}@" \
+                        "$(eval "echo \${area[${name}_p]"})" \
+                        "$(eval "echo \${line[${name}]"})" \
+                        "%{F$(eval "echo \${${name}_foreground}")}" \
+                        "%{B$(eval "echo \${${name}_background"})}" \
+                        "$(tr '\n' ' ' < <(bash < "$file"))" \
+                        "%{F-}%{B-}" \
+                        "$(eval "echo \${area[${name}_s]"})" \
+                        "%{-o}%{-uU-}" \
+                        $'\n' > "$process" &
+                done < <($(eval "echo \${${name}_reloadcommand"}))
+            fi
         else
-            while :; do
-                printf "%s" \
-                    "${name}@" \
-                    "$(eval "echo \${area[${name}_p]"})" \
-                    "$(eval "echo \${line[${name}]"})" \
-                    "%{F$(eval "echo \${${name}_foreground}")}" \
-                    "%{B$(eval "echo \${${name}_background"})}" \
-                    "$(tr '\n' ' ' < <(bash < "$file"))" \
-                    "%{F-}%{B-}" \
-                    "$(eval "echo \${area[${name}_s]"})" \
-                    "%{-o}%{-uU-}" \
-                    $'\n'
-                sleep $(eval "echo \${${name}_reload"})
-            done > "$process" &
+            if [[ $(eval "echo \${${name}_manual}") = true ]]; then
+                while :; do
+                    manual "$name" "$file"
+                    printf "%s" \
+                        "${name}@" \
+                        "${content}" \
+                        $'\n'
+                    sleep $(eval "echo \${${name}_reload"})
+                done > "$process" &
+            else
+                while :; do
+                    printf "%s" \
+                        "${name}@" \
+                        "$(eval "echo \${area[${name}_p]"})" \
+                        "$(eval "echo \${line[${name}]"})" \
+                        "%{F$(eval "echo \${${name}_foreground}")}" \
+                        "%{B$(eval "echo \${${name}_background"})}" \
+                        "$(tr '\n' ' ' < <(bash < "$file"))" \
+                        "%{F-}%{B-}" \
+                        "$(eval "echo \${area[${name}_s]"})" \
+                        "%{-o}%{-uU-}" \
+                        $'\n'
+                    sleep $(eval "echo \${${name}_reload"})
+                done > "$process" &
+            fi
         fi
     done
 } 2>&3

--- a/captain
+++ b/captain
@@ -125,7 +125,7 @@ manual() {
             handle["$1${area}"]="$(eval "echo \${${name}_${area}}")"
             format=$(sed "s/<@\($area\)@>/$1${area}/g" <<< "$format")
         done
-        content=$(tr '\n' ' ' < <(eval "$format"))
+        content=$(tr '\n' ' ' < <(echo "$output" | eval "$format"))
     } 2>&3
 }
 
@@ -238,12 +238,12 @@ manual() {
         if [[ "$(eval "echo \${${name}_reload"})" -eq "-1" ]]; then
             if [[ $(eval "echo \${${name}_manual}") = true ]]; then
                 while read -r output; do
-                    manual "$name" "$file" "$output"
+                    manual "$name" "$file"
                     printf "%s" \
                         "${name}@" \
                         "${content}" \
                         $'\n' > "$process" &
-                done < $(eval "echo \${${name}_reloadcommand"}) &
+                done < <($(eval "echo \${${name}_reloadcommand"})) &
             else
                  while read -r output; do
                     printf "%s" \

--- a/captain
+++ b/captain
@@ -238,12 +238,12 @@ manual() {
         if [[ "$(eval "echo \${${name}_reload"})" -eq "-1" ]]; then
             if [[ $(eval "echo \${${name}_manual}") = true ]]; then
                 while read -r output; do
-                    manual "$name" "$file"
+                    manual "$name" "$file" "$output"
                     printf "%s" \
                         "${name}@" \
                         "${content}" \
                         $'\n' > "$process" &
-                done < $(eval "echo \${${name}_reloadcommand"})
+                done < $(eval "echo \${${name}_reloadcommand"}) &
             else
                  while read -r output; do
                     printf "%s" \
@@ -252,12 +252,12 @@ manual() {
                         "$(eval "echo \${line[${name}]"})" \
                         "%{F$(eval "echo \${${name}_foreground}")}" \
                         "%{B$(eval "echo \${${name}_background"})}" \
-                        "$(tr '\n' ' ' < <(bash < "$file"))" \
+                        "$(tr '\n' ' ' < <(bash "$file" "$output"))" \
                         "%{F-}%{B-}" \
                         "$(eval "echo \${area[${name}_s]"})" \
                         "%{-o}%{-uU-}" \
                         $'\n' > "$process" &
-                done < <($(eval "echo \${${name}_reloadcommand"}))
+                done < <($(eval "echo \${${name}_reloadcommand"})) &
             fi
         else
             if [[ $(eval "echo \${${name}_manual}") = true ]]; then

--- a/captain.d/window
+++ b/captain.d/window
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Dependencies: bspc, siji
 
-bspc control --get-status | while read -r line; do
+while read -r line; do
     case $line in
         W*) window=""
             IFS=':'

--- a/captainrc
+++ b/captainrc
@@ -34,8 +34,7 @@ offset = 0
 
 [window]
 manual = true
-reload = -1
-reloadcommand = "bspc control --subscribe"
+reload = "bspc control --subscribe"
 
 ; You can use dashes, these will be converted to underscores later. This also
 ; means you need to reference to them with underscores in the script.
@@ -70,7 +69,6 @@ scroll-down = "notify-send 'Scrolled down!'"
 mouse-middle = "notify-send 'Middle click!'"
 mouse-left = "notify-send 'Left click!'"
 mouse-right = "notify-send 'Right click!'"
-reload  = -1
-reloadcommand = "xtitle -s"
+reload = "xtitle -s"
 
 # vim:syntax=dosini

--- a/captainrc
+++ b/captainrc
@@ -70,6 +70,6 @@ mouse-middle = "notify-send 'Middle click!'"
 mouse-left = "notify-send 'Left click!'"
 mouse-right = "notify-send 'Right click!'"
 reload  = -1
-reloadcommand = xtitle -s
+reloadcommand = "xtitle -s"
 
 # vim:syntax=dosini

--- a/captainrc
+++ b/captainrc
@@ -69,6 +69,7 @@ scroll-down = "notify-send 'Scrolled down!'"
 mouse-middle = "notify-send 'Middle click!'"
 mouse-left = "notify-send 'Left click!'"
 mouse-right = "notify-send 'Right click!'"
-reload  = 0.1
+reload  = -1
+reloadcommand = xtitle -s
 
 # vim:syntax=dosini

--- a/captainrc
+++ b/captainrc
@@ -34,7 +34,8 @@ offset = 0
 
 [window]
 manual = true
-reload = 0.1
+reload = -1
+reloadcommand = "bspc subscribe"
 
 ; You can use dashes, these will be converted to underscores later. This also
 ; means you need to reference to them with underscores in the script.

--- a/captainrc
+++ b/captainrc
@@ -35,7 +35,7 @@ offset = 0
 [window]
 manual = true
 reload = -1
-reloadcommand = "bspc subscribe"
+reloadcommand = "bspc control --subscribe"
 
 ; You can use dashes, these will be converted to underscores later. This also
 ; means you need to reference to them with underscores in the script.


### PR DESCRIPTION
This patch adds the ability to specify a `reload=-1` in your captainrc, along with a `reloadcommand`. If you do so, the related captain.d script will only be executed on output from `reloadcommand`. things like the window script won't have to query bspc every 0.1 seconds, instead only running on new input from bspc subscribe. 

edit: I believe this would help with https://github.com/muse/Captain/issues/8
