### PR TITLE
Fixed 2 issues and added a makefile to semi-automate the installation process

### DIFF
--- a/captain
+++ b/captain
@@ -34,14 +34,10 @@ cd $(dirname $0)
 captaindir=${XDG_CONFIG_HOME:-~/.config}/captain
 
 # Create the log file, and bind it to a file descriptor.
-if [[ ! -d "$captaindir" ]]; then
-    mkdir -p "$captaindir"
-fi && exec 3<> "$captaindir/captain.log"
+exec 3<> "$captaindir/captain.log"
 
-# Create the scripts directory.
-if [[ ! -d "$captaindir/captain.d" ]]; then
-    mkdir -p "$captaindir/captain.d"
-fi && treasure="$captaindir/captain.d"
+# Assign the scripts directory.
+treasure="$captaindir/captain.d"
 
 manuscript="$captaindir/captainrc"
 
@@ -169,9 +165,9 @@ manual() {
         [reload]=5)
     for file in $treasure/*; do
         name=$(basename $file)
-        if [[ $(eval "echo \${${name}_manual") = true ]]; then
+        if [[ $(eval "echo \${${name}_manual}") = true ]]; then
             echo "Manual mode has been enabled for ${name}."
-            if [[ $(eval "echo \${#${name}_reload") -eq 0 ]]; then
+            if [[ $(eval "echo \${#${name}_reload}") -eq 0 ]]; then
                 echo "No value for '${name}-$section' -> using ${choices[${section}]}"
                 eval "${name}_reload=${choices[reload]}"
             fi

--- a/captain.d/volume
+++ b/captain.d/volume
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 # Dependencies: amixer, siji
 
-# tries to get the master mixer
-mixer=$(amixer sget Master)
-
-if [[ $mixer != "" ]]; then
+# gets the master mixer
+# sometimes the card which contains the mixer may not come first so you have to iterate
+mixer=""
+card_no=0
+while [[ $mixer == "" ]]; do
+	mixer=$(amixer -c ${count} sget Master)
 	volume=$( echo $mixer | sed -n "0,/.*\[\([0-9]\+\)%\].*/s//\1/p")
 	state=$( echo $mixer | grep -Eoe '\[(on|off)\]')
-else
-	# gets the default mixer if it fails to get the master
-	volume=$( amixer -D default | sed -n "0,/.*\[\([0-9]\+\)%\].*/s//\1/p")
-	state=$( amixer -D default | grep -Eoe '\[(on|off)\]')
-fi
+	((card_no++))
+done
 
 if   [[ $volume -eq 0 || $state == '[off]' ]]; then
     token=''

--- a/captain.d/volume
+++ b/captain.d/volume
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 # Dependencies: amixer, siji
 
-volume=$(amixer sget Master | sed -n "0,/.*\[\([0-9]\+\)%\].*/s//\1/p")
-state=$(amixer sget Master | grep -Eoe '\[(on|off)\]')
+# tries to get the master mixer
+mixer=$(amixer sget Master)
+
+if [[ $mixer != "" ]]; then
+	volume=$( echo $mixer | sed -n "0,/.*\[\([0-9]\+\)%\].*/s//\1/p")
+	state=$( echo $mixer | grep -Eoe '\[(on|off)\]')
+else
+	# gets the default mixer if it fails to get the master
+	volume=$( amixer -D default | sed -n "0,/.*\[\([0-9]\+\)%\].*/s//\1/p")
+	state=$( amixer -D default | grep -Eoe '\[(on|off)\]')
+fi
 
 if   [[ $volume -eq 0 || $state == '[off]' ]]; then
     token=''

--- a/makefile
+++ b/makefile
@@ -1,0 +1,15 @@
+default:
+	@mkdir $${XDG_CONFIG_HOME:-~/.config}/captain/ && cd $${XDG_CONFIG_HOME:-~/.config}/captain/ && mkdir captain.d
+		
+install:
+	@cp -Rp captain.d/* $${XDG_CONFIG_HOME:-~/.config}/captain/captain.d/
+	@cp -p captainrc $${XDG_CONFIG_HOME:-~/.config}/captain/
+	@chmod +x captain
+	@sudo cp -p captain /usr/bin/
+
+uninstall:
+	@rm -fr $${XDG_CONFIG_HOME:-~/.config}/captain/
+	@sudo rm /usr/bin/captain
+	@echo "removed"
+
+.PHONY: default install uninstall


### PR DESCRIPTION
1. Fixed the probable issue where the Master mixer wasn't on the first card which resulted in an empty volume output

2. Fixed 2 bugs in the captain script which resulted in a EOF error

3. Added a MakeFile which automatically copies the files to their appropriate directories so the user does not have to. The installation part in the wiki just becomes
```
$ git clone https://github.com/muse/Captain
$ cd Captain
$ make
$ sudo make install
```
and the copy part can be removed. An uninstallation procedure is also added to the makefile. 